### PR TITLE
Fix: Update Dockerfile with new location to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /app/local_data_store && \
 WORKDIR /app
 
 # Install dependencies
-COPY requirements.txt .
+COPY goya_core/requirements.txt .
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir --quiet -r requirements.txt
 


### PR DESCRIPTION
When freshly cloning the repository we can see that a requirements.txt file no longer exists and has been moved to goya_cora. This Pull Request aims to fix this by updating the proper location in the Dockerfile